### PR TITLE
44 fix canvas

### DIFF
--- a/faci/urls.py
+++ b/faci/urls.py
@@ -3,7 +3,6 @@ from django.urls import path
 
 from faci.views import (
     FaciEditorView,
-    FaciEditAimView,
     FaciEditMembersView,
     FaciEditAgendaView,
     FaciEditPreparingView,
@@ -16,8 +15,6 @@ from faci.views import (
 
 
 urlpatterns = [
-    url(r'new/aim/$', FaciEditMembersView.as_view(), name='faci_editor_create'),
-    url(r'(?P<canvas_id>[0-9]+)/aim/$', FaciEditAimView.as_view(), name='faci_editor_aim'),
     url(r'(?P<canvas_id>[0-9]+)/member/(?P<invited_username>[0-9a-zA-Zа-яА-ЯёЁ_-]+)/$', FaciEditMembersView.as_view(), name='faci_editor_member'),
     url(r'(?P<canvas_id>[0-9]+)/agenda/$', FaciEditAgendaView.as_view(), name='faci_editor_agenda'),
     url(r'(?P<canvas_id>[0-9]+)/preparing/$', FaciEditPreparingView.as_view(), name='faci_editor_preparing'),
@@ -25,9 +22,9 @@ urlpatterns = [
     url(r'(?P<canvas_id>[0-9]+)/key_thoughts/$', FaciEditKeyThoughtsView.as_view(), name='faci_editor_key_thoughts'),
     url(r'(?P<canvas_id>[0-9]+)/agreements/$', FaciEditAgreementsView.as_view(), name='faci_editor_agreements'),
 
-    url(r'(?P<canvas_id>[0-9]+)/$', FaciEditorView.as_view(), name='faci_editor'),
-    path('new', FaciEditorView.as_view(), name='faci_new'),
+    url(r'(?P<canvas_id>[0-9]+)/$', FaciEditorView.as_view(), name='faci_editor_aim'),
+    url('new/', FaciEditorView.as_view(), name='faci_new'),
 
-    path('search_user/', SearchUserView.as_view(), name='search_user'),
+    url('search_user/', SearchUserView.as_view(), name='search_user'),
     path('', FaciListView.as_view(), name='faci_list'),
 ]

--- a/faci/urls.py
+++ b/faci/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 
 from faci.views import (
     FaciEditorView,
+    FaciEditAimView,
     FaciEditMembersView,
     FaciEditAgendaView,
     FaciEditPreparingView,
@@ -15,6 +16,8 @@ from faci.views import (
 
 
 urlpatterns = [
+    url(r'new/aim/$', FaciEditAimView.as_view(), name='faci_editor_create'),
+    url(r'(?P<canvas_id>[0-9]+)/aim/$', FaciEditAimView.as_view(), name='faci_editor_aim'),
     url(r'(?P<canvas_id>[0-9]+)/member/(?P<invited_username>[0-9a-zA-Zа-яА-ЯёЁ_-]+)/$', FaciEditMembersView.as_view(), name='faci_editor_member'),
     url(r'(?P<canvas_id>[0-9]+)/agenda/$', FaciEditAgendaView.as_view(), name='faci_editor_agenda'),
     url(r'(?P<canvas_id>[0-9]+)/preparing/$', FaciEditPreparingView.as_view(), name='faci_editor_preparing'),
@@ -22,7 +25,7 @@ urlpatterns = [
     url(r'(?P<canvas_id>[0-9]+)/key_thoughts/$', FaciEditKeyThoughtsView.as_view(), name='faci_editor_key_thoughts'),
     url(r'(?P<canvas_id>[0-9]+)/agreements/$', FaciEditAgreementsView.as_view(), name='faci_editor_agreements'),
 
-    url(r'(?P<canvas_id>[0-9]+)/$', FaciEditorView.as_view(), name='faci_editor_aim'),
+    url(r'(?P<canvas_id>[0-9]+)/$', FaciEditorView.as_view(), name='faci_editor'),
     url('new/', FaciEditorView.as_view(), name='faci_new'),
 
     url('search_user/', SearchUserView.as_view(), name='search_user'),

--- a/faci/views.py
+++ b/faci/views.py
@@ -70,8 +70,6 @@ class FaciEditorView(APIView):
         }
         return render(request, 'pages/faci_editor.html', context)
 
-
-class FaciEditAimView(APIView):
     def post(self, request, canvas_id=None):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
@@ -97,7 +95,7 @@ class FaciEditAimView(APIView):
                 faci_form.save()
                 data_for_return['id'] = faci_form.instance.pk
                 if not canvas_id:
-                    member = Member(invited=request.user, inviting=request.user, what_for='Инициатор встречи', faci_canvas=faci_form.instance)
+                    member = Member(invited=request.user, inviting=request.user, for_what='Инициатор встречи', faci_canvas=faci_form.instance)
                     member.save()
 
                 data_for_return['open_block'] = 'members'
@@ -121,7 +119,7 @@ class FaciEditMembersView(LoginRequiredMixin, APIView):
             member = member_queryset[0]
             if member.for_what != data['for_what']:
                 member.for_what = data['for_what']
-                member.save('for_what')
+                member.save()
         else:
             member = Member(invited=invited, for_what=data['for_what'], inviting=request.user, faci_canvas=faci_canvas)
             member.save()

--- a/faci/views.py
+++ b/faci/views.py
@@ -70,6 +70,8 @@ class FaciEditorView(APIView):
         }
         return render(request, 'pages/faci_editor.html', context)
 
+
+class FaciEditAimView(APIView):
     def post(self, request, canvas_id=None):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)

--- a/pages/templates/pages/faci_editor.html
+++ b/pages/templates/pages/faci_editor.html
@@ -8,7 +8,6 @@
 {% block content %}
     {{ members|json_script:'members_json' }}
     {{ agendas|json_script:'agendas_json' }}
-    
     <script>
         var URL_FACI_EDITOR_AGENDA = "agenda/";
         var URL_SEARCH_USER = "search_user/";

--- a/pages/templates/pages/faci_editor.html
+++ b/pages/templates/pages/faci_editor.html
@@ -12,7 +12,7 @@
     <script>
         var URL_FACI_EDITOR_AGENDA = "agenda/";
         var URL_SEARCH_USER = "search_user/";
-        var URL_FACI_EDITOR_AIM = "";
+        var URL_FACI_EDITOR_AIM = "aim/";
         var URL_FACI_EDITOR_PREPARING = "preparing/";
         var URL_FACI_EDITOR_START_MEETING = "meeting/";
         var URL_FACI_EDITOR_KEY_THOUTS = "key_thoughts/";

--- a/pages/templates/pages/faci_editor.html
+++ b/pages/templates/pages/faci_editor.html
@@ -13,9 +13,9 @@
         var URL_SEARCH_USER = "search_user/";
         var URL_FACI_EDITOR_AIM = "aim/";
         var URL_FACI_EDITOR_PREPARING = "preparing/";
-        var URL_FACI_EDITOR_START_MEETING = "meeting/";
+        var URL_FACI_EDITOR_START_MEETING = "start_meeting/";
         var URL_FACI_EDITOR_KEY_THOUTS = "key_thoughts/";
-        var URL_FACI_EDITOR_AGREEMENTS = "greements/";
+        var URL_FACI_EDITOR_AGREEMENTS = "agreements/";
         var URL_FACI_EDITOR_MEMBER = "member/";
         var CSRF_TOKEN = "{{ csrf_token }}";
     </script>

--- a/pages/templates/pages/faci_editor.html
+++ b/pages/templates/pages/faci_editor.html
@@ -8,6 +8,18 @@
 {% block content %}
     {{ members|json_script:'members_json' }}
     {{ agendas|json_script:'agendas_json' }}
+    
+    <script>
+        var URL_FACI_EDITOR_AGENDA = "agenda/";
+        var URL_SEARCH_USER = "search_user/";
+        var URL_FACI_EDITOR_AIM = "";
+        var URL_FACI_EDITOR_PREPARING = "preparing/";
+        var URL_FACI_EDITOR_START_MEETING = "meeting/";
+        var URL_FACI_EDITOR_KEY_THOUTS = "key_thoughts/";
+        var URL_FACI_EDITOR_AGREEMENTS = "greements/";
+        var URL_FACI_EDITOR_MEMBER = "member/";
+        var CSRF_TOKEN = "{{ csrf_token }}";
+    </script>
     <style>
         .card-body {
             position: relative;
@@ -261,9 +273,9 @@
             methods: {
                 save_agenda(component) {
                     $.ajax({
-                        url: 'agenda/',
+                        url: URL_FACI_EDITOR_AGENDA,
                         headers: {
-                            "X-CSRFToken": "{{ csrf_token }}",
+                            "X-CSRFToken": CSRF_TOKEN,
                         },
                         dataType: 'json',
                         data: {themes: component.m_themes, themes_duration: component.m_themes_duration, questions: component.m_questions},
@@ -390,17 +402,16 @@
                 ListdownField, ToggleField
             },
             methods: {
-                save_member() {
+                save_member(component) {
                     let self = this;
                     $.ajax({
-                        url: 'member/' + this.member.invited + '/',
+                        url: URL_FACI_EDITOR_MEMBER + self.member.invited + '/',
                         headers: {
-                            "X-CSRFToken": "{{ csrf_token }}",
+                            "X-CSRFToken": CSRF_TOKEN,
                         },
                         dataType: 'json',
-                        data: {for_what: this.member.for_what},
+                        data: {for_what: component.mvalue},
                         success: function(result) {
-                            console.log(result);
                             open_block(result['open_block']);
                             agenda_list.agendas.push({invited: self.member.invited, themes: '', themes_duration: 5, questions: '', self: self.member.invited == '{{request.user.username}}' });
                         },
@@ -413,9 +424,9 @@
                 },
                 search_user(component) {
                     $.ajax({
-                        url: "{% url 'search_user' %}",
+                        url: URL_SEARCH_USER,
                         headers: {
-                            "X-CSRFToken": "{{ csrf_token }}",
+                            "X-CSRFToken": CSRF_TOKEN,
                         },
                         dataType: 'json',
                         data: {search_string: component.query},
@@ -446,8 +457,7 @@
                     console.log(this.member);
                 },
                 blur_input_for_what(component) {
-                    console.log(this.member);
-                    this.save_member();
+                    this.save_member(component);
                 },
 
             },
@@ -500,9 +510,9 @@
     
         function save_form_aim(event) {
             $.ajax({
-                url: "aim/",
+                url: URL_FACI_EDITOR_AIM,
                 headers: {
-                    "X-CSRFToken": "{{ csrf_token }}",
+                    "X-CSRFToken": CSRF_TOKEN,
                 },
                 dataType: 'json',
                 data: $(event.target.form).serialize(),
@@ -534,9 +544,9 @@
         function save_form_preparing(event) {
             let form = event.target.form;
             $.ajax({
-                url: "preparing/",
+                url: URL_FACI_EDITOR_PREPARING,
                 headers: {
-                    "X-CSRFToken": "{{ csrf_token }}",
+                    "X-CSRFToken": CSRF_TOKEN,
                 },
                 dataType: 'json',
                 data: $(form).serialize(),
@@ -566,9 +576,9 @@
 
         function start_meeting(event) {
             $.ajax({
-                url: "start_meeting/",
+                url: URL_FACI_EDITOR_START_MEETING,
                 headers: {
-                    "X-CSRFToken": "{{ csrf_token }}",
+                    "X-CSRFToken": CSRF_TOKEN,
                 },
                 dataType: 'json',
                 data: {},
@@ -591,9 +601,9 @@
 
         function save_key_thoughts(event) {
             $.ajax({
-                url: "key_thoughts/",
+                url: URL_FACI_EDITOR_KEY_THOUTS,
                 headers: {
-                    "X-CSRFToken": "{{ csrf_token }}",
+                    "X-CSRFToken": CSRF_TOKEN,
                 },
                 dataType: 'json',
                 data: $(event.target.form).serialize(),
@@ -611,9 +621,9 @@
 
         function save_agreements(event) {
             $.ajax({
-                url: "agreements/",
+                url: URL_FACI_EDITOR_AGREEMENTS,
                 headers: {
-                    "X-CSRFToken": "{{ csrf_token }}",
+                    "X-CSRFToken": CSRF_TOKEN,
                 },
                 dataType: 'json',
                 data: $(event.target.form).serialize(),

--- a/pages/templates/template.html
+++ b/pages/templates/template.html
@@ -13,7 +13,7 @@
     <script src="{% static 'pages/windows.js' %}"></script>
     <link rel="stylesheet" href="{% static 'pages/windows.css' %}">
     <script src="{% static 'pages/extern/vue.3.js' %}"></script>
-    <script src="{% static 'pages/components.js' %}?v=2"></script>
+    <script src="{% static 'pages/components.js' %}"></script>
 </head>
 
 <body>

--- a/pages/templates/template.html
+++ b/pages/templates/template.html
@@ -13,7 +13,7 @@
     <script src="{% static 'pages/windows.js' %}"></script>
     <link rel="stylesheet" href="{% static 'pages/windows.css' %}">
     <script src="{% static 'pages/extern/vue.3.js' %}"></script>
-    <script src="{% static 'pages/components.js' %}"></script>
+    <script src="{% static 'pages/components.js' %}?v=2"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Теперь в блоке 2 сохраняется цель приглашения участника

Попутно было сделано:
- исправлена ошибка несохранения первого блока (вместо `for_what` было поле `what_for`)
- исправлен `path` на `url` в файле `faci/urls.py`
- в `pages/templates/pages/faci/faci_editor.html` ссылки из JS вынесены в переменную для избежания путанницы, которая привела к основной ошибке.

Pull Request закрывает Issue: https://github.com/TVP-Support/knowledge-api/issues/44