### PR TITLE
API заметок

### DIFF
--- a/note/load_from_github.py
+++ b/note/load_from_github.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from firebase_admin import credentials, firestore
 from typesense import Client
 
-from note.models import Note
+from note.models import Note, prepare_to_search
 
 
 def get_root_url(
@@ -21,10 +21,6 @@ def get_root_url(
     url_raw = f'https://raw.githubusercontent.com/{owner}/{repo}/main{directory}'
     url_page = f'https://github.com/{owner}/{repo}/blob/main{directory}'
     return url_raw if raw else url_page
-
-
-def prepare_to_search(value):
-    return value.lower().replace('ё', 'е')
 
 
 def download_from_github_archive(owner, repo, directory):
@@ -179,9 +175,8 @@ class UploaderDjangoServer:
         fields = Note(
             title=file_name,
             content=file_content,
-            search_content=prepare_to_search(file_content),
-            search_title=prepare_to_search(file_name),
         )
+        fields.fetch_search_fields()
         self.portion.append(fields)
 
     def commit(self):

--- a/note/load_from_github.py
+++ b/note/load_from_github.py
@@ -220,6 +220,24 @@ class UploaderDjangoServer:
         
         return None
 
+    def add(self, title, content):
+        note = Note(title=title, content=content)
+        note.fetch_search_fields()
+        note.save()
+        return {'title': note.title, 'content': note.content}
+
+    def edit(self, title, new_title=None, new_content=None):
+        note = Note.objects.get(title=title)
+        if new_title:
+            note.title = new_title
+
+        if new_content:
+            note.content = new_content
+
+        note.fetch_search_fields()
+        note.save()
+        return {'title': note.title, 'content': note.content}
+
 
 def get_class_name(camel_case):
     return 'Uploader{}'.format(camel_case.title().replace('_', ''))

--- a/note/load_from_github.py
+++ b/note/load_from_github.py
@@ -216,6 +216,14 @@ class UploaderDjangoServer:
 
         results = list(notes[offset:limit+offset].values(*fields))
         return dict(results=results, count=count)
+        
+    def get(self, title):
+        notes = Note.objects.filter(title=title)
+        if notes.exists():
+            note = notes[0]
+            return {'title': note.title, 'content': note.content}
+        
+        return None
 
 
 def get_class_name(camel_case):
@@ -243,24 +251,5 @@ def run_initiator(downloader, args_downloader, uploader, args_uploader):
     print('uploading is finished. Totally uploaded:', total_size + portion_size)
 
 
-def search(
-    uploader,
-    args_uploader,
-    operator,
-    limit,
-    offset,
-    fields,
-    file_name=None,
-    file_content=None,
-):
-    uploader = globals()[get_class_name(uploader)](*args_uploader)
-    data = uploader.search(
-        operator,
-        limit,
-        offset,
-        fields,
-        file_name,
-        file_content,
-    )
-    data['path'] = '{}/'.format(get_root_url())
-    return data
+def get_uploader(uploader_name, args_uploader):
+    return globals()[get_class_name(uploader_name)](*args_uploader)

--- a/note/models.py
+++ b/note/models.py
@@ -1,5 +1,9 @@
 from django.db import models
 
+  
+def prepare_to_search(value):
+    return value.lower().replace('ё', 'е')
+
 
 class Note(models.Model):
     title = models.CharField(verbose_name='Заголовок', max_length=255, null=False, db_index=True, unique=True)
@@ -11,3 +15,7 @@ class Note(models.Model):
         db_table = 'app_note_note'
         verbose_name = 'Заметка'
         verbose_name_plural = 'Заметки'
+
+    def fetch_search_fields(self):
+        self.search_content = prepare_to_search(self.content)
+        self.search_title = prepare_to_search(self.title)

--- a/note/serializers.py
+++ b/note/serializers.py
@@ -4,3 +4,4 @@ from rest_framework import serializers
 class NoteAddViewSerializer(serializers.Serializer):
     title = serializers.CharField(max_length=255)
     content = serializers.CharField(max_length=20000)
+    source = serializers.CharField(max_length=255, allow_blank=True)

--- a/note/serializers.py
+++ b/note/serializers.py
@@ -1,0 +1,6 @@
+from rest_framework import serializers
+
+
+class NoteAddViewSerializer(serializers.Serializer):
+    title = serializers.CharField(max_length=255)
+    content = serializers.CharField(max_length=20000)

--- a/note/serializers.py
+++ b/note/serializers.py
@@ -2,6 +2,15 @@ from rest_framework import serializers
 
 
 class NoteAddViewSerializer(serializers.Serializer):
-    title = serializers.CharField(max_length=255)
     content = serializers.CharField(max_length=20000)
-    source = serializers.CharField(max_length=255, allow_blank=True)
+
+
+class NoteEditViewSerializer(serializers.Serializer):
+    new_title = serializers.CharField(max_length=255)
+    new_content = serializers.CharField(max_length=20000)
+
+    def validate(self, data):
+        if data['new_title'] is None and data['new_content'] is None:
+            raise serializers.ValidationError("required new_title or new_content, or both")
+
+        return data

--- a/note/serializers.py
+++ b/note/serializers.py
@@ -6,11 +6,11 @@ class NoteAddViewSerializer(serializers.Serializer):
 
 
 class NoteEditViewSerializer(serializers.Serializer):
-    new_title = serializers.CharField(max_length=255)
-    new_content = serializers.CharField(max_length=20000)
+    new_title = serializers.CharField(max_length=255, required=False)
+    new_content = serializers.CharField(max_length=20000, required=False)
 
     def validate(self, data):
-        if data['new_title'] is None and data['new_content'] is None:
+        if not data.get('new_title') and not data.get('new_content'):
             raise serializers.ValidationError("required new_title or new_content, or both")
 
         return data

--- a/note/urls_api.py
+++ b/note/urls_api.py
@@ -1,8 +1,10 @@
 from django.urls import path
 
-from note.views import note_search, note_hook
+from note.views import NoteAddView, NoteGetView, note_search, note_hook
 
 urlpatterns = [
     path('search/<str:query>/', note_search, name='api_note_search'),
+    path('get/<str:title>/', NoteGetView.as_view(), name='api_note_get'),
+    path('add//', NoteAddView.as_view(), name='api_note_add'),
     path('hook/', note_hook, name='api_note_hook'),
 ]

--- a/note/urls_api.py
+++ b/note/urls_api.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from note.views import NoteAddView, NoteGetView, note_search, note_hook
+from note.views import NoteAddView, NoteEditView, NoteGetView, note_search, note_hook
 
 urlpatterns = [
     path('search/<str:query>/', note_search, name='api_note_search'),
     path('get/<str:title>/', NoteGetView.as_view(), name='api_note_get'),
-    path('add//', NoteAddView.as_view(), name='api_note_add'),
+    path('add/<str:title>/', NoteAddView.as_view(), name='api_note_add'),
+    path('edit/<str:title>/', NoteEditView.as_view(), name='api_note_edit'),
     path('hook/', note_hook, name='api_note_hook'),
 ]

--- a/note/views.py
+++ b/note/views.py
@@ -17,7 +17,7 @@ from rest_framework import status
 from note.load_from_github import prepare_to_search, get_uploader, get_root_url
 from note.credentials import args_uploader
 from note.models import Note
-from note.serializers import NoteAddViewSerializer
+from note.serializers import NoteAddViewSerializer, NoteEditViewSerializer
 
 
 @api_view(('GET',))
@@ -52,8 +52,6 @@ def note_search(request, query):
     uploader_name = request.GET.get('source', settings.DEFAULT_UPLOADER)
     uploader = get_uploader(uploader_name, args_uploader[uploader_name])
     data = uploader.search(
-        #uploader,
-        #args_uploader[uploader_name],
         operator=operator,
         limit=limit,
         offset=offset,
@@ -140,21 +138,50 @@ def note_hook(request):
 class NoteAddView(APIView):
     """Класс метода для добавления заметки"""
 
-    def post(self, request):
+    def post(self, request, title):
         serializer = NoteAddViewSerializer(data=request.POST)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        uploader_name = data.get('source', settings.DEFAULT_UPLOADER)
+
+        title = unquote(title)
+
+        uploader_name = request.GET.get('source', settings.DEFAULT_UPLOADER)
         uploader = get_uploader(uploader_name, args_uploader[uploader_name])
-        note_data = uploader.get(title=data['title'])
+        note_data = uploader.get(title=title)
         if note_data:
             data = {'detail': 'Заметка с таким названием уже существует'}
             return Response(status=status.HTTP_200_OK, data=data)
 
-        note = Note(title=data['title'], content=data['content'])
-        note.fetch_search_fields()
-        data = {}
-        return Response(status=status.HTTP_200_OK, data=data)
+        note_data = uploader.add(title, data['content'])
+        note_data['source'] = uploader_name
+        return Response(status=status.HTTP_200_OK, data=note_data)
+
+
+class NoteEditView(APIView):
+    """Класс метода для редактирования заметки"""
+
+    def post(self, request, title):
+        serializer = NoteEditViewSerializer(data=request.POST)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        title = unquote(title)
+        new_title = data['new_title']
+        new_content = data['new_content']
+
+        uploader_name = request.GET.get('source', settings.DEFAULT_UPLOADER)
+        uploader = get_uploader(uploader_name, args_uploader[uploader_name])
+        if not uploader.get(title=title):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        note_data = uploader.get(title=new_title)
+        if note_data:
+            data = {'detail': 'Заметка с таким названием уже существует'}
+            return Response(status=status.HTTP_200_OK, data=data)
+
+        note_data = uploader.edit(title, new_title, new_content)
+        note_data['source'] = uploader_name
+        return Response(status=status.HTTP_200_OK, data=note_data)
 
 
 class NoteGetView(APIView):

--- a/pages/templates/pages/faci_editor.html
+++ b/pages/templates/pages/faci_editor.html
@@ -485,7 +485,6 @@
                     this.member_list.push({'id': '', 'invited': '', 'inviting': '{{ request.user.username }}', 'for_what': 'цель приглашения?', 'edit': true});
                     setTimeout(function() {
                         member_items = $('#app>table')[0].children;
-                        console.log(member_items[member_items.length-1]);
                         member_items[member_items.length-1].querySelector('.button_ss').click();
                     }, 20);
                 },

--- a/pages/templates/pages/faci_editor.html
+++ b/pages/templates/pages/faci_editor.html
@@ -484,6 +484,9 @@
                 add_member(event) {
                     this.member_list.push({'id': '', 'invited': '', 'inviting': '{{ request.user.username }}', 'for_what': 'цель приглашения?', 'edit': true});
                     setTimeout(function() {
+                        member_items = $('#app>table')[0].children;
+                        console.log(member_items[member_items.length-1]);
+                        member_items[member_items.length-1].querySelector('.button_ss').click();
                     }, 20);
                 },
             },


### PR DESCRIPTION
Добавлено API заметок для:
- добавления
- редактирования
- получения

Изменения в API:
1. Метод получения заметок `note/title` превращается в `note/get/title`
2. Метод добавления заметок `note/add` превращается в `note/add/title?source=db_name`, `content` передаётся не в query, в теле запроса
3. Добавлен метод редактирования заметок `note/edit/title?source=db_name`, в теле запроса передаётся `new_title`, `new_content`

Первые 2 пункта устраняют путаницы - методы теперь унифицированы.

Функцию `prepare_to_search` перенёс в файл модели, так как она используется вместе с ней. Обоснование, почему сделал генерацию полей поиска в отдельном методе модели, а не в `save`: https://dvmn.org/encyclopedia/django/dont-overridde-common-model-methods/ 

close #24 